### PR TITLE
Bump swift-syntax upper bound to ..<604

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Swift Syntax Compatibility Check
-        uses: davdroman/swift-macro-compatibility-check@from-version
+        uses: davdroman/swift-macro-compatibility-check@main
         with:
           run-tests: false
           from-version: "601.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -81,7 +81,7 @@ package.targets += [
 
 package.dependencies += [
 	.package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
-	.package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0"),
+	.package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"604.0.0"),
 ]
 
 for target in package.targets {


### PR DESCRIPTION
## Summary
- Bump swift-syntax dependency upper bound from `..<"603.0.0"` to `..<"604.0.0"` to support swift-syntax 603